### PR TITLE
Pinning helm version to avoid error in blueprint addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Truefoundry EKS Module
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.57 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.9 |
 
 ## Providers
 
@@ -20,7 +21,7 @@ Truefoundry EKS Module
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws-eks-kubernetes-cluster"></a> [aws-eks-kubernetes-cluster](#module\_aws-eks-kubernetes-cluster) | terraform-aws-modules/eks/aws | v20.33.1 |
-| <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | 1.19.0 |
+| <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | 1.21.0 |
 
 ## Resources
 

--- a/eks_addons.tf
+++ b/eks_addons.tf
@@ -5,7 +5,7 @@
 module "eks_blueprints_addons" {
   count   = var.use_existing_cluster ? 0 : 1
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "1.19.0"
+  version = "1.21.0"
 
   cluster_name      = module.aws-eks-kubernetes-cluster[0].cluster_name
   cluster_endpoint  = module.aws-eks-kubernetes-cluster[0].cluster_endpoint

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.57"
     }
+    # Added here because the upstream provider breaks
+    # https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/452
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.9"
+    }
   }
 }


### PR DESCRIPTION
1. Pinning helm version to be lower then 3.0.0 because of breaking changes introduced in that version - https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/452