### PR TITLE
Moving EKS to version 1.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Truefoundry EKS Module
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws-eks-kubernetes-cluster"></a> [aws-eks-kubernetes-cluster](#module\_aws-eks-kubernetes-cluster) | terraform-aws-modules/eks/aws | v21.15.1 |
+| <a name="module_aws-eks-kubernetes-cluster"></a> [aws-eks-kubernetes-cluster](#module\_aws-eks-kubernetes-cluster) | terraform-aws-modules/eks/aws | v21.18.0 |
 | <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | 1.23.0 |
 
 ## Resources
@@ -68,7 +68,7 @@ Truefoundry EKS Module
 | <a name="input_cluster_kms_key_source_policy_documents"></a> [cluster\_kms\_key\_source\_policy\_documents](#input\_cluster\_kms\_key\_source\_policy\_documents) | List of IAM policy documents that are merged together into the cluster KMS key policy. Statements must have unique `sid`s | `list(string)` | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster. If use\_existing\_cluster is set to true, cluster\_name will be used to fetch details only | `string` | n/a | yes |
 | <a name="input_cluster_security_group_additional_rules"></a> [cluster\_security\_group\_additional\_rules](#input\_cluster\_security\_group\_additional\_rules) | List of additional security group rules to add to the cluster security group created. Set `source_node_security_group = true` inside rules to set the `node_security_group` as source | `any` | `{}` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS cluster version | `string` | `"1.34"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS cluster version | `string` | `"1.35"` | no |
 | <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether a log group is created by this module for the cluster logs. If not, AWS will automatically create one if logging is enabled | `bool` | `true` | no |
 | <a name="input_eks_managed_node_group_defaults"></a> [eks\_managed\_node\_group\_defaults](#input\_eks\_managed\_node\_group\_defaults) | Managed node group defaults | `any` | `{}` | no |
 | <a name="input_enable_cluster_creator_admin_permissions"></a> [enable\_cluster\_creator\_admin\_permissions](#input\_enable\_cluster\_creator\_admin\_permissions) | Enable admin permission for the user who created the cluster | `bool` | `true` | no |

--- a/eks.tf
+++ b/eks.tf
@@ -5,7 +5,7 @@
 module "aws-eks-kubernetes-cluster" {
   count                         = var.use_existing_cluster ? 0 : 1
   source                        = "terraform-aws-modules/eks/aws"
-  version                       = "v21.15.1"
+  version                       = "v21.18.0"
   name                          = var.cluster_name
   kubernetes_version            = var.cluster_version
   create_iam_role               = var.cluster_iam_role_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -121,7 +121,7 @@ variable "cluster_endpoint_public_access_cidrs" {
 variable "cluster_version" {
   description = "EKS cluster version"
   type        = string
-  default     = "1.34"
+  default     = "1.35"
 }
 
 variable "cluster_authentication_mode" {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrading the EKS control plane default version and the underlying EKS Terraform module can trigger cluster/managed addon changes and potential compatibility issues during apply/upgrade.
> 
> **Overview**
> Updates the EKS module to target **Kubernetes `1.35` by default** (from `1.34`) via `cluster_version`.
> 
> Bumps the `terraform-aws-modules/eks/aws` dependency from `v21.15.1` to `v21.18.0`, and refreshes the generated `README.md` module/version docs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b393f03c5c81ec0e469d7b05dc53b2d3da760f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->